### PR TITLE
Use website favicon for web viewer tabs

### DIFF
--- a/src/components/NavigationTreeItem.tsx
+++ b/src/components/NavigationTreeItem.tsx
@@ -84,7 +84,11 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 	};
 
 	useEffect(() => {
-		if (iconEl && iconEl.current) setIcon(iconEl.current, props.icon);
+		if (/http|base64/.test(props.icon)) return;
+
+		if (iconEl && iconEl.current) {
+			setIcon(iconEl.current, props.icon)
+		}
 	}, [props.icon]);
 
 	useEffect(() => {
@@ -93,92 +97,103 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 		}
 	}, [props.isCollapsed]);
 
-	if (Platform.isMobile) {
-		return (
+	return Platform.isMobile ? (
+		<div
+			className={toClassName(itemElClasses)}
+			data-type={props.dataType}
+			data-id={props.dataId}
+			style={{ minHeight: props.isCollapsed ? 0 : height }}
+			ref={props.ref}
+		>
 			<div
-				className={toClassName(itemElClasses)}
-				data-type={props.dataType}
-				data-id={props.dataId}
-				style={{ minHeight: props.isCollapsed ? 0 : height }}
-				ref={props.ref}
+				className={toClassName(selfElClasses)}
+				onClick={props.onClick}
+				onTouchStart={props.onTouchStart}
+				onTouchMove={props.onTouchMove}
+				onTouchEnd={props.onTouchEnd}
+				onAuxClick={props.onAuxClick}
+				onDoubleClick={props.onDoubleClick}
+				onContextMenu={props.onContextMenu}
 			>
-				<div
-					className={toClassName(selfElClasses)}
-					onClick={props.onClick}
-					onTouchStart={props.onTouchStart}
-					onTouchMove={props.onTouchMove}
-					onTouchEnd={props.onTouchEnd}
-					onAuxClick={props.onAuxClick}
-					onDoubleClick={props.onDoubleClick}
-					onContextMenu={props.onContextMenu}
-				>
+				{/http|base64/.test(props.icon) ? (
+					<img
+						src={props.icon}
+						className="tree-item-icon"
+					/>
+				) : (
 					<div className="tree-item-icon" ref={iconEl}></div>
-					<div className="tree-item-inner">
-						<div className="tree-item-inner-text">
-							{props.title}
-						</div>
-					</div>
-					<div
-						className="tree-item-flair-outer"
-						onClick={(e) => e.stopPropagation()}
-					>
-						{props.toolbar}
-						<div
-							className="drag-handle"
-							ref={props.id ? setNodeRef : null}
-							{...attributes}
-							{...listeners}
-						>
-							<IconButton
-								icon="grip-vertical"
-								action="drag-handle"
-							/>
-						</div>
+				)}
+				<div className="tree-item-inner">
+					<div className="tree-item-inner-text">
+						{props.title}
 					</div>
 				</div>
-				{!props.isCollapsed && !isDragging && (
-					<div className="tree-item-children">{props.children}</div>
-				)}
-			</div>
-		);
-	} else {
-		return (
-			<div
-				className={toClassName(itemElClasses)}
-				data-type={props.dataType}
-				data-id={props.dataId}
-				style={{ minHeight: props.isCollapsed ? 0 : height }}
-				ref={props.ref}
-			>
 				<div
-					className={toClassName(selfElClasses)}
-					onClick={props.onClick}
-					onAuxClick={props.onAuxClick}
-					onDoubleClick={props.onDoubleClick}
-					onContextMenu={props.onContextMenu}
-					onMouseOver={props.onMouseOver}
-					data-index={props.index}
-					ref={props.id ? setNodeRef : null}
-					{...attributes}
-					{...listeners}
+					className="tree-item-flair-outer"
+					onClick={(e) => e.stopPropagation()}
 				>
-					<div className="tree-item-icon" ref={iconEl}></div>
-					<div className="tree-item-inner">
-						<div className="tree-item-inner-text">
-							{props.title}
-						</div>
-					</div>
+					{props.toolbar}
 					<div
-						className="tree-item-flair-outer"
-						onClick={(e) => e.stopPropagation()}
+						className="drag-handle"
+						ref={props.id ? setNodeRef : null}
+						{...attributes}
+						{...listeners}
 					>
-						{props.toolbar}
+						<IconButton
+							icon="grip-vertical"
+							action="drag-handle"
+						/>
 					</div>
 				</div>
-				{!props.isCollapsed && !isDragging && (
-					<div className="tree-item-children">{props.children}</div>
-				)}
 			</div>
-		);
-	}
+			{!props.isCollapsed && !isDragging && (
+				<div className="tree-item-children">{props.children}</div>
+			)}
+		</div>
+	) : (
+
+		<div
+			className={toClassName(itemElClasses)}
+			data-type={props.dataType}
+			data-id={props.dataId}
+			style={{ minHeight: props.isCollapsed ? 0 : height }}
+			ref={props.ref}
+		>
+			<div
+				className={toClassName(selfElClasses)}
+				onClick={props.onClick}
+				onAuxClick={props.onAuxClick}
+				onDoubleClick={props.onDoubleClick}
+				onContextMenu={props.onContextMenu}
+				onMouseOver={props.onMouseOver}
+				data-index={props.index}
+				ref={props.id ? setNodeRef : null}
+				{...attributes}
+				{...listeners}
+			>
+				{/http|base64/.test(props.icon) ? (
+					<img
+						src={props.icon}
+						className="tree-item-icon"
+					/>
+				) : (
+					<div className="tree-item-icon" ref={iconEl}></div>
+				)}
+				<div className="tree-item-inner">
+					<div className="tree-item-inner-text">
+						{props.title}
+					</div>
+				</div>
+				<div
+					className="tree-item-flair-outer"
+					onClick={(e) => e.stopPropagation()}
+				>
+					{props.toolbar}
+				</div>
+			</div>
+			{!props.isCollapsed && !isDragging && (
+				<div className="tree-item-children">{props.children}</div>
+			)}
+		</div>
+	)
 };

--- a/src/components/NavigationTreeItem.tsx
+++ b/src/components/NavigationTreeItem.tsx
@@ -12,6 +12,7 @@ interface NavigationTreeItemProps {
 	ref?: React.RefObject<HTMLDivElement | null>;
 	title: string | React.ReactNode;
 	icon: string;
+	webviewIcon: string;
 	isTab: boolean;
 	isEphemeralTab?: boolean;
 	isTabSlot?: boolean;
@@ -84,12 +85,10 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 	};
 
 	useEffect(() => {
-		if (/http|base64/.test(props.icon)) return;
-
 		if (iconEl && iconEl.current) {
 			setIcon(iconEl.current, props.icon)
 		}
-	}, [props.icon]);
+	}, [props.icon, props.webviewIcon]);
 
 	useEffect(() => {
 		if (props.children && props.children instanceof Array) {
@@ -115,14 +114,12 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 				onDoubleClick={props.onDoubleClick}
 				onContextMenu={props.onContextMenu}
 			>
-				{/http|base64/.test(props.icon) ? (
-					<img
-						src={props.icon}
-						className="tree-item-icon"
-					/>
-				) : (
-					<div className="tree-item-icon" ref={iconEl}></div>
-				)}
+				<img
+					src={props.webviewIcon || undefined}
+					className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'unset' : 'none' }}
+				/>
+				<div className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'none' : 'unset' }} ref={iconEl}></div>
+
 				<div className="tree-item-inner">
 					<div className="tree-item-inner-text">
 						{props.title}
@@ -171,14 +168,12 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 				{...attributes}
 				{...listeners}
 			>
-				{/http|base64/.test(props.icon) ? (
-					<img
-						src={props.icon}
-						className="tree-item-icon"
-					/>
-				) : (
-					<div className="tree-item-icon" ref={iconEl}></div>
-				)}
+				<img
+					src={props.webviewIcon || undefined}
+					className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'unset' : 'none' }}
+				/>
+				<div className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'none' : 'unset' }} ref={iconEl}></div>
+
 				<div className="tree-item-inner">
 					<div className="tree-item-inner-text">
 						{props.title}

--- a/src/components/NavigationTreeItem.tsx
+++ b/src/components/NavigationTreeItem.tsx
@@ -86,7 +86,13 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 
 	useEffect(() => {
 		if (iconEl && iconEl.current) {
-			setIcon(iconEl.current, props.icon)
+			if (props?.webviewIcon) {
+				iconEl.current.replaceChildren(
+					createEl("img", { attr: { src: props.webviewIcon } })
+				);
+			} else {
+				setIcon(iconEl.current, props.icon);
+			}
 		}
 	}, [props.icon, props?.webviewIcon]);
 
@@ -96,99 +102,92 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 		}
 	}, [props.isCollapsed]);
 
-	return Platform.isMobile ? (
-		<div
-			className={toClassName(itemElClasses)}
-			data-type={props.dataType}
-			data-id={props.dataId}
-			style={{ minHeight: props.isCollapsed ? 0 : height }}
-			ref={props.ref}
-		>
+	if (Platform.isMobile) {
+		return (
 			<div
-				className={toClassName(selfElClasses)}
-				onClick={props.onClick}
-				onTouchStart={props.onTouchStart}
-				onTouchMove={props.onTouchMove}
-				onTouchEnd={props.onTouchEnd}
-				onAuxClick={props.onAuxClick}
-				onDoubleClick={props.onDoubleClick}
-				onContextMenu={props.onContextMenu}
+				className={toClassName(itemElClasses)}
+				data-type={props.dataType}
+				data-id={props.dataId}
+				style={{ minHeight: props.isCollapsed ? 0 : height }}
+				ref={props.ref}
 			>
-				<img
-					src={props.webviewIcon || undefined}
-					className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'unset' : 'none' }}
-				/>
-				<div className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'none' : 'unset' }} ref={iconEl}></div>
-
-				<div className="tree-item-inner">
-					<div className="tree-item-inner-text">
-						{props.title}
-					</div>
-				</div>
 				<div
-					className="tree-item-flair-outer"
-					onClick={(e) => e.stopPropagation()}
+					className={toClassName(selfElClasses)}
+					onClick={props.onClick}
+					onTouchStart={props.onTouchStart}
+					onTouchMove={props.onTouchMove}
+					onTouchEnd={props.onTouchEnd}
+					onAuxClick={props.onAuxClick}
+					onDoubleClick={props.onDoubleClick}
+					onContextMenu={props.onContextMenu}
 				>
-					{props.toolbar}
+					<div className="tree-item-icon" ref={iconEl}></div>
+					<div className="tree-item-inner">
+						<div className="tree-item-inner-text">
+							{props.title}
+						</div>
+					</div>
 					<div
-						className="drag-handle"
-						ref={props.id ? setNodeRef : null}
-						{...attributes}
-						{...listeners}
+						className="tree-item-flair-outer"
+						onClick={(e) => e.stopPropagation()}
 					>
-						<IconButton
-							icon="grip-vertical"
-							action="drag-handle"
-						/>
+						{props.toolbar}
+						<div
+							className="drag-handle"
+							ref={props.id ? setNodeRef : null}
+							{...attributes}
+							{...listeners}
+						>
+							<IconButton
+								icon="grip-vertical"
+								action="drag-handle"
+							/>
+						</div>
 					</div>
 				</div>
+				{!props.isCollapsed && !isDragging && (
+					<div className="tree-item-children">{props.children}</div>
+				)}
 			</div>
-			{!props.isCollapsed && !isDragging && (
-				<div className="tree-item-children">{props.children}</div>
-			)}
-		</div>
-	) : (
-
-		<div
-			className={toClassName(itemElClasses)}
-			data-type={props.dataType}
-			data-id={props.dataId}
-			style={{ minHeight: props.isCollapsed ? 0 : height }}
-			ref={props.ref}
-		>
+		);
+	} else {
+		return (
 			<div
-				className={toClassName(selfElClasses)}
-				onClick={props.onClick}
-				onAuxClick={props.onAuxClick}
-				onDoubleClick={props.onDoubleClick}
-				onContextMenu={props.onContextMenu}
-				onMouseOver={props.onMouseOver}
-				data-index={props.index}
-				ref={props.id ? setNodeRef : null}
-				{...attributes}
-				{...listeners}
+				className={toClassName(itemElClasses)}
+				data-type={props.dataType}
+				data-id={props.dataId}
+				style={{ minHeight: props.isCollapsed ? 0 : height }}
+				ref={props.ref}
 			>
-				<img
-					src={props.webviewIcon || undefined}
-					className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'unset' : 'none' }}
-				/>
-				<div className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'none' : 'unset' }} ref={iconEl}></div>
-
-				<div className="tree-item-inner">
-					<div className="tree-item-inner-text">
-						{props.title}
+				<div
+					className={toClassName(selfElClasses)}
+					onClick={props.onClick}
+					onAuxClick={props.onAuxClick}
+					onDoubleClick={props.onDoubleClick}
+					onContextMenu={props.onContextMenu}
+					onMouseOver={props.onMouseOver}
+					data-index={props.index}
+					ref={props.id ? setNodeRef : null}
+					{...attributes}
+					{...listeners}
+				>
+					<div className="tree-item-icon" ref={iconEl}></div>
+					<div className="tree-item-inner">
+						<div className="tree-item-inner-text">
+							{props.title}
+						</div>
+					</div>
+					<div
+						className="tree-item-flair-outer"
+						onClick={(e) => e.stopPropagation()}
+					>
+						{props.toolbar}
 					</div>
 				</div>
-				<div
-					className="tree-item-flair-outer"
-					onClick={(e) => e.stopPropagation()}
-				>
-					{props.toolbar}
-				</div>
+				{!props.isCollapsed && !isDragging && (
+					<div className="tree-item-children">{props.children}</div>
+				)}
 			</div>
-			{!props.isCollapsed && !isDragging && (
-				<div className="tree-item-children">{props.children}</div>
-			)}
-		</div>
-	)
+		);
+	}
 };

--- a/src/components/NavigationTreeItem.tsx
+++ b/src/components/NavigationTreeItem.tsx
@@ -12,7 +12,7 @@ interface NavigationTreeItemProps {
 	ref?: React.RefObject<HTMLDivElement | null>;
 	title: string | React.ReactNode;
 	icon: string;
-	webviewIcon: string;
+	webviewIcon?: string;
 	isTab: boolean;
 	isEphemeralTab?: boolean;
 	isTabSlot?: boolean;
@@ -88,7 +88,7 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 		if (iconEl && iconEl.current) {
 			setIcon(iconEl.current, props.icon)
 		}
-	}, [props.icon, props.webviewIcon]);
+	}, [props.icon, props?.webviewIcon]);
 
 	useEffect(() => {
 		if (props.children && props.children instanceof Array) {
@@ -116,9 +116,9 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 			>
 				<img
 					src={props.webviewIcon || undefined}
-					className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'unset' : 'none' }}
+					className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'unset' : 'none' }}
 				/>
-				<div className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'none' : 'unset' }} ref={iconEl}></div>
+				<div className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'none' : 'unset' }} ref={iconEl}></div>
 
 				<div className="tree-item-inner">
 					<div className="tree-item-inner-text">
@@ -170,9 +170,9 @@ export const NavigationTreeItem = (props: NavigationTreeItemProps) => {
 			>
 				<img
 					src={props.webviewIcon || undefined}
-					className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'unset' : 'none' }}
+					className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'unset' : 'none' }}
 				/>
-				<div className="tree-item-icon" style={{ display: /http|base64/.test(props.webviewIcon) ? 'none' : 'unset' }} ref={iconEl}></div>
+				<div className="tree-item-icon" style={{ display: /http|base64/.test(props?.webviewIcon||'') ? 'none' : 'unset' }} ref={iconEl}></div>
 
 				<div className="tree-item-inner">
 					<div className="tree-item-inner-text">

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -541,7 +541,8 @@ export const Tab = ({
 		observer.observe(view.faviconImgEl, { attributes: true, subtree: true });
 
 		if(faviconInterval){
-			faviconInterval = clearInterval(faviconInterval) ?? null
+			clearInterval(faviconInterval)
+			faviconInterval = null
 		}
 
 		if(!view?.faviconImgEl?.children.length) return


### PR DESCRIPTION
This PR implements #127 by setting the currently open webview favicon as the corresponding vertical tab item.

At the moment, the icon is updated every time the favicon changes, but I couldn't figure out how to update the icon when the tab is loaded for the first time.


https://github.com/user-attachments/assets/602bb7f1-0ef3-452a-a6e0-487110d5b047

