### PR TITLE
make new tab in group a button

### DIFF
--- a/src/components/Group.tsx
+++ b/src/components/Group.tsx
@@ -4,6 +4,7 @@ import { IconButton } from "./IconButton";
 import { DEFAULT_GROUP_TITLE, useViewState } from "src/models/ViewState";
 import { useApp, useSettings } from "src/models/PluginContext";
 import { GroupType } from "src/models/VTWorkspace";
+import { moveTabToEnd } from "src/services/MoveTab";
 import { Menu, WorkspaceParent } from "obsidian";
 import { EVENTS } from "src/constants/Events";
 import {
@@ -125,6 +126,20 @@ export const Group = ({ type, children, group }: GroupProps) => {
 
 	const toolbar = (
 		<Fragment>
+			{!isSidebar && !isEditing && group && (
+				<IconButton
+					icon="plus"
+					action="new-tab"
+					tooltip="New tab"
+					onClick={(e) => {
+						e.stopPropagation();
+						const leaf = workspace.getLeaf("split");
+						moveTabToEnd(app, leaf.id, group);
+						workspace.setActiveLeaf(leaf, { focus: true });
+						workspace.onLayoutChange();
+					}}
+				/>
+			)}
 			{!isSidebar && !isEditing && (
 				<IconButton
 					icon="pencil"

--- a/src/components/Group.tsx
+++ b/src/components/Group.tsx
@@ -136,7 +136,7 @@ export const Group = ({ type, children, group }: GroupProps) => {
 						const leaf = workspace.getLeaf("split");
 						moveTabToEnd(app, leaf.id, group);
 						workspace.setActiveLeaf(leaf, { focus: true });
-						workspace.onLayoutChange();
+						// Removed manual call to workspace.onLayoutChange();
 					}}
 				/>
 			)}

--- a/src/components/NavigationContent.tsx
+++ b/src/components/NavigationContent.tsx
@@ -18,7 +18,6 @@ import { CssClasses, toClassName } from "src/utils/CssClasses";
 import { SortableContext } from "@dnd-kit/sortable";
 import { createPortal } from "react-dom";
 import { moveTab, moveTabToEnd, moveTabToNewGroup } from "src/services/MoveTab";
-import { TabSlot } from "./TabSlot";
 import { GroupSlot } from "./GroupSlot";
 import { Identifier } from "src/models/VTWorkspace";
 import { WorkspaceLeaf } from "obsidian";
@@ -99,7 +98,7 @@ export const NavigationContent = () => {
 
 	const getLeaveIDs = (groupID: Identifier) => {
 		const group = content.get(groupID);
-		return [...group.leafIDs, `slot-${groupID}`];
+		return [...group.leafIDs];
 	};
 
 	const entryOf = (groupID: Identifier) => {
@@ -144,7 +143,6 @@ export const NavigationContent = () => {
 												);
 											}
 										)}
-										<TabSlot groupID={groupID} />
 									</SortableContext>
 								)}
 							</Group>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,7 +5,6 @@
 @use "styles/TabHandle.scss";
 @use "styles/TabIndexViewCue.scss";
 @use "styles/Group.scss";
-@use "styles/TabSlot.scss";
 @use "styles/GroupSlot.scss";
 @use "styles/ToggleSidebar.scss";
 @use "styles/DropIndicator.scss";


### PR DESCRIPTION
I dont like the current way of opening a new tab in a group using the UI. It shifts the rest of the content down and is just hard to reach and unintuitive in my opinion.

https://github.com/user-attachments/assets/911eca9e-6216-436a-b0d7-4d1cc7237994

Here is an alternative:
https://github.com/user-attachments/assets/22fc2c67-e910-4dce-9440-36f6dccf6adc

This was vibe-coded by GPT-5...